### PR TITLE
Fix seo-canonical to allow manual definition of canonical url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function plugin(options) {
             var data = files[file];
             data.seo = data.seo || {};
 
-            data.seo.canonical = options.canonicalBase;
+            data.seo.canonical = data.seo.canonical || options.canonicalBase;
 
             //Check if path exists in this context
             //i.e. index/archival pages


### PR DESCRIPTION
Adding in this branch will allow for front-matter/metalsmith to define canonical urls manually. This is necessary for list pages, where we want to define the canonical as the root of the list not /page2/ or /page3/ etc. If there is no canonical url set, will default to the standard canonical base